### PR TITLE
Rename configuration option #restore to #persist

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ run MyRackApp
 
 ```ruby
 RequestStore::Sidekiq.configure do |config|
-  # Enable store restoring a job execution.
-  config.restore = true
+  # Enable store persistance at job execution.
+  config.persist = true
 end
 ```
 

--- a/lib/request_store/sidekiq/client_middleware.rb
+++ b/lib/request_store/sidekiq/client_middleware.rb
@@ -10,7 +10,7 @@ module RequestStore
       end
 
       def store_request_store?(item)
-        ::RequestStore::Sidekiq.configuration.restore &&
+        ::RequestStore::Sidekiq.configuration.persist &&
           item['request_store'].blank?
       end
     end

--- a/lib/request_store/sidekiq/configuration.rb
+++ b/lib/request_store/sidekiq/configuration.rb
@@ -15,10 +15,10 @@ module RequestStore
 
     # Configuration variables and defaults.
     class Configuration
-      attr_accessor :restore
+      attr_accessor :persist
 
       def initialize
-        @restore = false
+        @persist = false
       end
     end
   end

--- a/lib/request_store/sidekiq/server_middleware.rb
+++ b/lib/request_store/sidekiq/server_middleware.rb
@@ -12,7 +12,7 @@ module RequestStore
       end
 
       def restore_request_store?(job)
-        ::RequestStore::Sidekiq.configuration.restore &&
+        ::RequestStore::Sidekiq.configuration.persist &&
           job['request_store'].present?
       end
     end

--- a/spec/request_store/sidekiq/server_middleware_spec.rb
+++ b/spec/request_store/sidekiq/server_middleware_spec.rb
@@ -14,19 +14,19 @@ RSpec.describe RequestStore::Sidekiq::ServerMiddleware do
     end
   end
 
-  shared_examples 'a restored request store' do
+  shared_examples 'a persisted request store' do
     before do
       # ClientMiddleware setup the store.
       job['request_store'] = store
     end
 
-    context 'when restoring is enabled' do
+    context 'when persistance is enabled' do
       before do
-        ::RequestStore::Sidekiq.configure { |config| config.restore = true }
+        ::RequestStore::Sidekiq.configure { |config| config.persist = true }
       end
 
       after do
-        ::RequestStore::Sidekiq.configure { |config| config.restore = false }
+        ::RequestStore::Sidekiq.configure { |config| config.persist = false }
       end
 
       it 'restores the request store' do
@@ -36,7 +36,7 @@ RSpec.describe RequestStore::Sidekiq::ServerMiddleware do
       end
     end
 
-    context 'when restoring is disabled' do
+    context 'when persistance is disabled' do
       it 'do not restores the request store' do
         subject.call(worker, job, queue) do
           expect(::RequestStore.store).to eq({})
@@ -54,7 +54,7 @@ RSpec.describe RequestStore::Sidekiq::ServerMiddleware do
     end
 
     it_behaves_like 'a cleared request store'
-    it_behaves_like 'a restored request store'
+    it_behaves_like 'a persisted request store'
   end
 
   context 'when the worker completes successfully' do
@@ -66,6 +66,6 @@ RSpec.describe RequestStore::Sidekiq::ServerMiddleware do
     end
 
     it_behaves_like 'a cleared request store'
-    it_behaves_like 'a restored request store'
+    it_behaves_like 'a persisted request store'
   end
 end


### PR DESCRIPTION
`persist` or `persistance` have a better sense than `restore`